### PR TITLE
Implement more-general DOCHAZKA_LDAP_MAPPING parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
   - ./Build
   - ./Build install
   - perl bin/dochazka-dbinit
-  - ./Build test --verbose
+  - ./Build test

--- a/MANIFEST
+++ b/MANIFEST
@@ -61,7 +61,7 @@ META.json
 META.yml
 README.rst
 t/001-noauto.t
-t/LDAP.t
+t/ldap.t
 t/dispatch/001-resource.t
 t/dispatch/activity.t
 t/dispatch/component.t

--- a/config/REST_Config.pm
+++ b/config/REST_Config.pm
@@ -151,10 +151,19 @@ set( 'DOCHAZKA_LDAP_SERVER', 'ldaps://ldap.dochazka.site' );
 #     base DN
 set( 'DOCHAZKA_LDAP_BASE', 'dc=dochazka,dc=site' );
 
-# DOCHAZKA_LDAP_NICK_MAPPING
-#     in order for LDAP authentication to work, the Dochazka 'nick' must
-#     be mapped to a field in the LDAP database (e.g. 'uid', 'cn', etc.)
-set( 'DOCHAZKA_LDAP_NICK_MAPPING', 'uid' );
+# DOCHAZKA_LDAP_MAPPING
+#     in order for LDAP authentication to work, the employee fields that
+#     Dochazka uses, such as 'nick', 'fullname', 'email', etc. must be mapped
+#     to corresponding fields in the LDAP database (e.g. 'uid', 'cn', etc.) -
+#     that is accomplished via this parameter
+#     WARNING: change the values only, never the keys! The only exception is
+#     that you can optionally add a 'sec_id' key if appropriate for your LDAP
+#     database.
+set( 'DOCHAZKA_LDAP_MAPPING', {
+    'nick' => 'uid',
+    'fullname' => 'cn',
+    'email' => 'mail',
+});
 
 # DOCHAZKA_LDAP_FILTER
 #     filter
@@ -167,13 +176,6 @@ set( 'DOCHAZKA_LDAP_TEST_UID_EXISTENT', 'I_exist_in_local_LDAP' );
 # DOCHAZKA_LDAP_TEST_UID_NON_EXISTENT
 #     a non-existent UID for LDAP testing (t/201-LDAP.t)
 set( 'DOCHAZKA_LDAP_TEST_UID_NON_EXISTENT', 'I_do_NOT_exist_in_local_LDAP' );
-
-# DOCHAZKA_LDAP_POPULATE_MATRIX
-#     set of key => value pairs where key is Employee object property and value
-#     is the matching LDAP property; used to populate employee objects with
-#     values from LDAP (do *not* include nick mapping here - use
-#     DOCHAZKA_LDAP_NICK_MAPPING for that)
-set( 'DOCHAZKA_LDAP_POPULATE_MATRIX', {} );
 
 # DOCHAZKA_REST_SESSION_EXPIRATION_TIME
 #     number of seconds after which a session will be considered stale

--- a/ext/REST_SiteConfig.pm.example
+++ b/ext/REST_SiteConfig.pm.example
@@ -79,10 +79,19 @@
 #     base DN
 #set( 'DOCHAZKA_LDAP_BASE', 'dc=dochazka,dc=site' );
 
-# DOCHAZKA_LDAP_NICK_MAPPING
-#     in order for LDAP authentication to work, the Dochazka 'nick' must
-#     be mapped to a field in the LDAP database (e.g. 'uid', 'cn', etc.)
-#set( 'DOCHAZKA_LDAP_NICK_MAPPING', 'uid' );
+# DOCHAZKA_LDAP_MAPPING
+#     in order for LDAP authentication to work, the employee fields that
+#     Dochazka uses, such as 'nick', 'fullname', 'email', etc. must be mapped
+#     to corresponding fields in the LDAP database (e.g. 'uid', 'cn', etc.) -
+#     that is accomplished via this parameter
+#     WARNING: change the values only, never the keys! The only exception is
+#     that you can optionally add a 'sec_id' key if appropriate for your LDAP
+#     database.
+#set( 'DOCHAZKA_LDAP_MAPPING', {
+#    'nick' => 'uid',
+#    'fullname' => 'cn',
+#    'email' => 'mail',
+#});
 
 # DOCHAZKA_LDAP_FILTER
 #     filter
@@ -95,13 +104,6 @@
 # DOCHAZKA_LDAP_TEST_UID_NON_EXISTENT
 #     a non-existent UID for LDAP testing (t/201-LDAP.t)
 #set( 'DOCHAZKA_LDAP_TEST_UID_NON_EXISTENT', 'I_do_NOT_exist_in_local_LDAP' );
-
-# DOCHAZKA_LDAP_POPULATE_MATRIX
-#     set of key => value pairs where key is Employee object property and value
-#     is the matching LDAP property; used to populate employee objects with
-#     values from LDAP (do *not* include nick mapping here - use
-#     DOCHAZKA_LDAP_NICK_MAPPING for that)
-#set( 'DOCHAZKA_LDAP_POPULATE_MATRIX', {} );
 
 # DOCHAZKA_REST_SESSION_EXPIRATION_TIME
 #     number of seconds after which a session will be considered stale

--- a/lib/App/Dochazka/REST/LDAP.pm
+++ b/lib/App/Dochazka/REST/LDAP.pm
@@ -118,7 +118,7 @@ sub ldap_search {
     my ( $ldap, $nick, $prop ) = @_;
     $nick = $nick || '';
     my $base = $site->DOCHAZKA_LDAP_BASE || '';
-    my $field = $site->DOCHAZKA_LDAP_NICK_MAPPING || ''; 
+    my $field = $site->DOCHAZKA_LDAP_MAPPING->{nick} || '';
     my $filter = $site->DOCHAZKA_LDAP_FILTER || '';
     my $prop_value;
 
@@ -214,8 +214,8 @@ sub populate_employee {
 
     # get LDAP properties and stuff them into the employee object
     my $count = 0;
-    foreach my $key ( keys( %{ $site->DOCHAZKA_LDAP_POPULATE_MATRIX } ) ) {
-        my $prop = $site->DOCHAZKA_LDAP_POPULATE_MATRIX->{ $key };
+    foreach my $key ( keys( %{ $site->DOCHAZKA_LDAP_MAPPING } ) ) {
+        my $prop = $site->DOCHAZKA_LDAP_MAPPING->{ $key };
         my $value = ldap_search( $ldap, $emp->nick, $prop );
         last unless $value;
         $log->debug( "Setting $key to $value" );

--- a/lib/App/Dochazka/REST/LDAP.pm
+++ b/lib/App/Dochazka/REST/LDAP.pm
@@ -229,5 +229,4 @@ sub populate_employee {
     return $CELL->status_not_ok;
 }
 
-
 1;

--- a/lib/App/Dochazka/REST/Model/Employee.pm
+++ b/lib/App/Dochazka/REST/Model/Employee.pm
@@ -36,7 +36,7 @@ use 5.012;
 use strict;
 use warnings;
 use App::CELL qw( $CELL $log $meta $site );
-use App::Dochazka::REST::LDAP;
+use App::Dochazka::REST::LDAP qw( populate_employee );
 use App::Dochazka::REST::Model::Shared qw( 
     cud 
     load 
@@ -389,6 +389,24 @@ sub delete {
     return $status;
 }
 
+
+=head2 sync
+
+Sync the mapping fields to the values found in the LDAP database.
+
+=cut
+
+sub sync {
+    my $self = shift;
+    my $status = populate_employee( $self );
+    if ( $status->ok ) {
+        foreach my $key ( keys( %{ $site->DOCHAZKA_LDAP_MAPPING } ) ) {
+            my $value = $site->DOCHAZKA_LDAP_MAPPING->{ $key };
+            $self->set( $key, $value );
+        }
+    }
+    return $status;
+}
 
 
 =head2 load_by_eid

--- a/lib/App/Dochazka/REST/Test.pm
+++ b/lib/App/Dochazka/REST/Test.pm
@@ -151,7 +151,7 @@ sub initialize_regression_test {
     );
     plan skip_all => "Web::MREST::init failed: " . $status->text unless $status->ok;
 
-    diag( "DOCHAZKA_STATE_DIR is set to " . $site->DOCHAZKA_STATE_DIR );
+    #diag( "DOCHAZKA_STATE_DIR is set to " . $site->DOCHAZKA_STATE_DIR );
 
     note( "Set log level" );
     $log->init( 


### PR DESCRIPTION
Replaces DOCHAZKA_LDAP_NICK_MAPPING and DOCHAZKA_LDAP_POPULATE_MATRIX

Fixes: https://github.com/smithfarm/dochazka-rest/issues/99
Signed-off-by: Nathan Cutler <ncutler@suse.com>